### PR TITLE
Refactor: 챗봇 채팅 인증 및 사용자 프로필 연동 로직 추가

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -57,7 +57,17 @@ def extract_member_id_from_cookie(request: Request) -> int:
 
 @app.post("/api/chat", response_model=ChatResponse)
 async def chat(req: ChatRequest, request: Request):
-    req.user_info["session_id"] = str(extract_member_id_from_cookie(request))
+    member_id = extract_member_id_from_cookie(request)
+    req.user_info["session_id"] = str(member_id)
+    try:
+        profile = chat_service._get_user_profile(member_id)
+        req.user_info["name"] = profile["name"]
+        req.user_info["creditScore"] = profile["credit"]
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:
+        print(f"_get_user_profile error: {exc}")
+        raise HTTPException(status_code=500, detail="사용자 조회 중 오류가 발생했습니다.") from exc
 
     return StreamingResponse(
         chat_service.stream_answer(

--- a/app/services.py
+++ b/app/services.py
@@ -137,5 +137,39 @@ class ChatService:
             print(f"Error in stream_answer: {e}")
             yield "죄송합니다. 답변을 생성하는 중에 오류가 발생했습니다."
 
+    def _get_user_profile(self, member_id: int):
+        conn = self._get_db_connection()
+        cur = conn.cursor()
+        try:
+            query = """
+                SELECT
+                    m.name,
+                    ch.credit_score
+                FROM member m
+                LEFT JOIN (
+                    SELECT DISTINCT ON (member_id)
+                        member_id,
+                        credit_score
+                    FROM credit_history
+                    ORDER BY member_id, credit_history_id DESC
+                ) ch ON ch.member_id = m.member_id
+                WHERE m.member_id = %s
+            """
+            cur.execute(query, (member_id,))
+            row = cur.fetchone()
+
+            if not row:
+                raise ValueError("회원 정보를 찾을 수 없습니다.")
+
+            name, credit = row
+            return {
+                "name": name,
+                "credit": credit if credit is not None else "확인되지 않음"
+            }
+        finally:
+            cur.close()
+            conn.close()
+
+
 # 싱글톤 패턴으로 서비스 인스턴스 생성
 chat_service = ChatService()


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #16 

---

### 📝 작업 내용
- 로그인한 사용자의 프로필(이름, 신용점수 등)을 챗봇 로직과 연동
---

### 📷 스크린샷 (선택)
<img width="372" height="486" alt="image" src="https://github.com/user-attachments/assets/4ef40173-a6ba-409f-8443-ebdeb807c81b" />

아래와 같이 변경

<img width="372" height="480" alt="image" src="https://github.com/user-attachments/assets/008ace6f-0ce4-456d-92b3-7d97e1636373" />


---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 채팅 API에서 사용자 프로필 정보(이름, 신용점수) 조회 기능 추가

* **개선**
  * 사용자 정보 조회 실패 시 오류 응답 처리 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->